### PR TITLE
Fix RGBA to RGB conversion issue in image processing

### DIFF
--- a/scripts/postprocessing_pixelization.py
+++ b/scripts/postprocessing_pixelization.py
@@ -150,7 +150,14 @@ def process(img):
 
     img = img.crop((left, top, right, bottom))
 
-    trans = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+    # Ensure the image is in RGB format
+    if img.mode != 'RGB':
+        img = img.convert('RGB')
+
+    trans = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
+    ])
 
     return trans(img)[None, :, :, :]
 


### PR DESCRIPTION
This pull request fixes an issue where RGBA images cause a tensor size mismatch error during the normalization step. I've added a line to convert images to RGB mode before processing, which solves the problem.